### PR TITLE
Add macOS status bar app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Rust build artifacts
+/tat/target/
+
+# Swift build artifacts
+/TATMacApp/.build/
+/TATMacApp/Package.resolved

--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@
 - `tat start <task>`：開始追蹤任務。
 - `tat end <task>`：手動結束任務。
 - `tat list`：列出所有任務及其累積時間。
+
+## 編譯方式
+
+### CLI 版本
+進入 `tat` 目錄後執行：
+
+```bash
+cargo build --release
+```
+
+完成後可在 `target/release/tat` 找到可執行檔。
+
+### macOS 介面版
+macOS 需要 Swift 及 Xcode。使用下列方式產生執行檔：
+
+```bash
+xcrun xcodebuild -scheme TATMacApp -configuration Release
+```
+
+或直接以 Xcode 開啟 `TATMacApp/Package.swift` 進行建置。此版本在狀態列會顯示目前執行中的任務與經過時間。

--- a/TATMacApp/Package.swift
+++ b/TATMacApp/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "TATMacApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.14.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "TATMacApp",
+            dependencies: [
+                .product(name: "SQLite", package: "SQLite.swift")
+            ]
+        )
+    ]
+)

--- a/TATMacApp/Sources/TATMacApp/ContentView.swift
+++ b/TATMacApp/Sources/TATMacApp/ContentView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var vm: TaskViewModel
+    @State private var taskName: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                TextField("Task name", text: $taskName)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button(vm.isRunning ? "Stop" : "Start") {
+                    if vm.isRunning {
+                        vm.stopCurrentTask()
+                    } else {
+                        vm.startTask(name: taskName)
+                    }
+                }
+                .disabled(taskName.isEmpty && !vm.isRunning)
+            }
+            .padding()
+
+            List {
+                ForEach(vm.summaries) { summary in
+                    NavigationLink(destination: TaskDetailView(task: summary)) {
+                        HStack {
+                            Text(summary.name)
+                            Spacer()
+                            Text(vm.format(duration: summary.total))
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            vm.refreshSummaries()
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}

--- a/TATMacApp/Sources/TATMacApp/StatusBarView.swift
+++ b/TATMacApp/Sources/TATMacApp/StatusBarView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct StatusBarView: View {
+    @EnvironmentObject var vm: TaskViewModel
+
+    var body: some View {
+        HStack {
+            if vm.isRunning {
+                Text("Running: \(vm.currentTaskName)")
+                Spacer()
+                Text(vm.elapsedTimeString)
+            } else {
+                Text("No task running")
+            }
+        }
+        .padding()
+    }
+}

--- a/TATMacApp/Sources/TATMacApp/TaskDetailView.swift
+++ b/TATMacApp/Sources/TATMacApp/TaskDetailView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct TaskDetailView: View {
+    @EnvironmentObject var vm: TaskViewModel
+    var task: TaskSummary
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(vm.records.filter { $0.taskName == task.name }) { rec in
+                    HStack {
+                        Text(vm.dateFormatter.string(from: rec.datetime))
+                        Spacer()
+                        Text(rec.action)
+                    }
+                    .contextMenu {
+                        Button("Delete") {
+                            vm.deleteRecord(rec)
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                vm.refreshRecords(for: task.name)
+            }
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+}

--- a/TATMacApp/Sources/TATMacApp/TaskViewModel.swift
+++ b/TATMacApp/Sources/TATMacApp/TaskViewModel.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+import Combine
+import SQLite
+
+struct TaskRecord: Identifiable {
+    let id: Int64
+    let taskName: String
+    let datetime: Date
+    let action: String
+}
+
+struct TaskSummary: Identifiable {
+    let id = UUID()
+    let name: String
+    let total: TimeInterval
+}
+
+class TaskViewModel: ObservableObject {
+    @Published var summaries: [TaskSummary] = []
+    @Published var records: [TaskRecord] = []
+    @Published var isRunning: Bool = false
+    @Published var currentTaskName: String = ""
+    @Published var elapsedTime: TimeInterval = 0
+
+    private var timer: Timer?
+    private var startDate: Date?
+
+    let db: Connection
+    let tasksTable = Table("tasks")
+    let idExp = Expression<Int64>("id")
+    let datetimeExp = Expression<String>("datetime")
+    let nameExp = Expression<String>("task_name")
+    let actionExp = Expression<String>("action")
+
+    let dateFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return fmt
+    }()
+
+    init() {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("tasks.db")
+        db = try! Connection(url.path)
+        try? db.run(tasksTable.create(ifNotExists: true) { t in
+            t.column(idExp, primaryKey: .autoincrement)
+            t.column(datetimeExp)
+            t.column(nameExp)
+            t.column(actionExp)
+        })
+        refreshSummaries()
+    }
+
+    func startTask(name: String) {
+        currentTaskName = name
+        startDate = Date()
+        isRunning = true
+        elapsedTime = 0
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            self.elapsedTime += 1
+        }
+        log(action: "start")
+    }
+
+    func stopCurrentTask() {
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+        log(action: "end")
+        refreshSummaries()
+    }
+
+    private func log(action: String) {
+        guard let startDate else { return }
+        let dt = dateFormatter.string(from: Date())
+        try? db.run(tasksTable.insert(datetimeExp <- dt, nameExp <- currentTaskName, actionExp <- action))
+    }
+
+    func refreshSummaries() {
+        var startTimes: [String: Date] = [:]
+        var totals: [String: TimeInterval] = [:]
+        records.removeAll()
+        for row in try! db.prepare(tasksTable.order(datetimeExp.asc)) {
+            let dt = dateFormatter.date(from: row[datetimeExp]) ?? Date()
+            let name = row[nameExp]
+            let act = row[actionExp]
+            records.append(TaskRecord(id: row[idExp], taskName: name, datetime: dt, action: act))
+            if act == "start" {
+                startTimes[name] = dt
+            } else if act == "end" {
+                if let s = startTimes.removeValue(forKey: name) {
+                    let diff = dt.timeIntervalSince(s)
+                    totals[name, default: 0] += diff
+                }
+            }
+        }
+        summaries = totals.map { TaskSummary(name: $0.key, total: $0.value) }
+    }
+
+    func refreshRecords(for name: String) {
+        records = records.filter { $0.taskName == name }
+    }
+
+    func deleteRecord(_ rec: TaskRecord) {
+        let row = tasksTable.filter(idExp == rec.id)
+        try? db.run(row.delete())
+        refreshSummaries()
+    }
+
+    func format(duration: TimeInterval) -> String {
+        let seconds = Int(duration)
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        let s = seconds % 60
+        return String(format: "%02d:%02d:%02d", h, m, s)
+    }
+
+    var elapsedTimeString: String {
+        format(duration: elapsedTime)
+    }
+}

--- a/TATMacApp/Sources/TATMacApp/main.swift
+++ b/TATMacApp/Sources/TATMacApp/main.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct TATMacApp: App {
+    @StateObject private var viewModel = TaskViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+        MenuBarExtra("TAT", systemImage: "stopwatch") {
+            StatusBarView()
+                .environmentObject(viewModel)
+        }
+        .menuBarExtraStyle(.window)
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI macOS app `TATMacApp` with status bar item
- update README with build instructions
- ignore build artifacts

## Testing
- `cargo build`
- `cargo test`
- `swift build` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685277ef36e48322b387abc9ff920098